### PR TITLE
Allow test tags to be specified from gobuild.toml

### DIFF
--- a/default_template.go
+++ b/default_template.go
@@ -5,6 +5,7 @@ var defaultTemplate = `
   ignoreDirs = [".git", "Godeps", "vendor"]
   stopLoadingParent = [".git"]
   buildFlags = ["."]
+  testFlags = ["-covermode", "atomic", "-race", "-timeout", "10s", "-cpu", "4", "-parallel", "8"]
   artifactsEnv = "CIRCLE_ARTIFACTS"
   testReportEnv = "CIRCLE_TEST_REPORTS"
   duplLimit = "100"

--- a/template.go
+++ b/template.go
@@ -119,7 +119,7 @@ func (b *buildTemplate) BuildFlags() []string {
 }
 
 func (b *buildTemplate) TestCoverageArgs() []string {
-	return []string{"-covermode", "atomic", "-race", "-timeout", "10s", "-cpu", "4", "-parallel", "8"}
+	return b.varStrArray("testFlags")
 }
 
 func (b *buildTemplate) MetalintIgnoreLines() []string {


### PR DESCRIPTION
Happy New Year!

This PR addresses issue #2, added the default TestFlags value to the default_template and allowed it to be overwritten via gobuild.toml.
